### PR TITLE
fixed makefile issue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ EXTRA_CFLAGS=
 EXTRA_CXXFLAGS=
 
 # Set to 1 to enable hot/cold linking
-USE_PACKAGE:=1
+USE_PACKAGE:=0
 
 # Add libraries you do not wish to include in the cold image here
 # EXCLUDE_COLD_LIBRARIES:= $(FWDIR)/your_library.a


### PR DESCRIPTION
On Thursday we couldn't build anything it kept erroring out. Changing 
`USE_PACKAGE:=1` to `USE_PACKAGE:=0` worked.